### PR TITLE
Add option to disable pvc alerting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repo.
-*       @jschaefe-akw @tmthang
+*       @Gagarmel @tmthang

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_cluster_policy"></a> [cluster\_policy](#input\_cluster\_policy) | Set this to `false` if you don't want to create the cluster policy. | `bool` | `true` | no |
 | <a name="input_email_alert_recipient"></a> [email\_alert\_recipient](#input\_email\_alert\_recipient) | The email alert address. | `string` | `null` | no |
 | <a name="input_enable_job_alerting"></a> [enable\_job\_alerting](#input\_enable\_job\_alerting) | Determines whether to alert on job errors. | `bool` | `true` | no |
+| <a name="input_enable_volume_alerting"></a> [enable\_volume\_alerting](#input\_enable\_volume\_alerting) | Determines whether to alert on volume usage. | `bool` | `true` | no |
 | <a name="input_google_chat_alert_url"></a> [google\_chat\_alert\_url](#input\_google\_chat\_alert\_url) | The Google Chat alert channel webhook URL. | `string` | `null` | no |
 | <a name="input_namespaces"></a> [namespaces](#input\_namespaces) | List of namespaces to be monitored. | `list(string)` | `[]` | no |
 

--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -94,7 +94,7 @@ resource "newrelic_nrql_alert_condition" "pod-not-ready" {
 resource "newrelic_nrql_alert_condition" "job_not_ready" {
   for_each = toset(var.namespaces)
 
-  enabled                        = var.enable_job_alerting
+  enabled = var.enable_job_alerting
 
   name                           = "Job is not ready"
   title_template                 = "Job {{tags.podName}} is not ready"
@@ -174,6 +174,8 @@ resource "newrelic_nrql_alert_condition" "replicaset-not-desired-amount" {
 
 resource "newrelic_nrql_alert_condition" "volume_out_of_space" {
   for_each = toset(var.namespaces)
+
+  enabled = var.enable_volume_alerting
 
   name                           = "PVC is running out of space"
   title_template                 = "PVC {{tags.pvcName}} is running out of space"

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "enable_job_alerting" {
   default     = true
   description = "Determines whether to alert on job errors."
 }
+
+variable "enable_volume_alerting" {
+  type        = bool
+  default     = true
+  description = "Determines whether to alert on volume usage."
+}


### PR DESCRIPTION
This pull request includes several changes to enhance alerting capabilities and update code ownership. The most important changes include adding a new alerting variable for volume usage, updating the `README.md` to reflect this new variable, and modifying the `CODEOWNERS` file to change the default owners.

Enhancements to alerting capabilities:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR41-R46): Added a new variable `enable_volume_alerting` to determine whether to alert on volume usage.
* [`namespace_policy.tf`](diffhunk://#diff-7b892cf9d537a3385d4c902a72c1590599549e66fa2d3e07a51d09bfd3c3ad7aR178-R179): Enabled the new volume alerting feature by using the `enable_volume_alerting` variable in the `newrelic_nrql_alert_condition` resource.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58): Updated the documentation to include the new `enable_volume_alerting` variable.

Code ownership updates:

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bL2-R2): Changed the default owners from `@jschaefe-akw` to `@Gagarmel`.