### PR TITLE
Multiple channels are not required anymore

### DIFF
--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -207,9 +207,7 @@ resource "newrelic_nrql_alert_condition" "volume_out_of_space" {
 }
 
 resource "newrelic_notification_channel" "email_namespace" {
-  for_each = {
-    for policy in newrelic_alert_policy.namespace : policy.name => policy if var.email_alert_recipient != null
-  }
+  count = var.email_alert_recipient != null ? 1 : 0
 
   name           = each.key
   type           = "EMAIL"
@@ -223,9 +221,7 @@ resource "newrelic_notification_channel" "email_namespace" {
 }
 
 resource "newrelic_notification_channel" "google_chat_namespace" {
-  for_each = {
-    for policy in newrelic_alert_policy.namespace : policy.name => policy if var.google_chat_alert_url != null
-  }
+  count = var.google_chat_alert_url != null ? 1 : 0
 
   name           = each.key
   type           = "WEBHOOK"

--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -209,7 +209,7 @@ resource "newrelic_nrql_alert_condition" "volume_out_of_space" {
 resource "newrelic_notification_channel" "email_namespace" {
   count = var.email_alert_recipient != null ? 1 : 0
 
-  name           = each.key
+  name           = var.channel_name
   type           = "EMAIL"
   destination_id = newrelic_notification_destination.email[0].id
   product        = "IINT"
@@ -223,7 +223,7 @@ resource "newrelic_notification_channel" "email_namespace" {
 resource "newrelic_notification_channel" "google_chat_namespace" {
   count = var.google_chat_alert_url != null ? 1 : 0
 
-  name           = each.key
+  name           = var.channel_name
   type           = "WEBHOOK"
   destination_id = newrelic_notification_destination.google_chat[0].id
   product        = "IINT" // (Workflows)


### PR DESCRIPTION
This pull request includes changes to the `namespace_policy.tf` file to update the configuration of New Relic notification channels. The most important changes involve switching from using the `for_each` construct to using the `count` parameter for conditional resource creation.

Updates to New Relic notification channels:

* `resource "newrelic_notification_channel" "email_namespace"`: Replaced `for_each` with `count` to conditionally create the resource based on the `var.email_alert_recipient` variable. Updated the `name` attribute to use `var.channel_name`.
* `resource "newrelic_notification_channel" "google_chat_namespace"`: Replaced `for_each` with `count` to conditionally create the resource based on the `var.google_chat_alert_url` variable. Updated the `name` attribute to use `var.channel_name`.