### PR TITLE
Fix channel references

### DIFF
--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -337,7 +337,7 @@ resource "newrelic_workflow" "namespace" {
       destination.name => destination if var.email_alert_recipient != null
     }
     content {
-      channel_id = newrelic_notification_channel.email_namespace[newrelic_alert_policy.namespace[0].name].id
+      channel_id = newrelic_notification_channel.email_namespace[0].id
     }
   }
 
@@ -347,7 +347,7 @@ resource "newrelic_workflow" "namespace" {
       destination.name => destination if var.google_chat_alert_url != null
     }
     content {
-      channel_id = newrelic_notification_channel.google_chat_namespace[newrelic_alert_policy.namespace[0].name].id
+      channel_id = newrelic_notification_channel.google_chat_namespace[0].id
     }
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `namespace_policy.tf` file to simplify the way channel IDs are referenced in the `newrelic_workflow` resource. The most important changes are:

* Simplified the `channel_id` assignment for email notifications by directly referencing the first element in the `newrelic_notification_channel.email_namespace` array.
* Simplified the `channel_id` assignment for Google Chat notifications by directly referencing the first element in the `newrelic_notification_channel.google_chat_namespace` array.