### PR TITLE
Use `channel_name` as name

### DIFF
--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -311,7 +311,7 @@ resource "newrelic_notification_channel" "google_chat_namespace" {
 resource "newrelic_workflow" "namespace" {
   count = length(var.namespaces) > 0 ? 1 : 0
 
-  name                  = newrelic_alert_policy.namespace[0].name
+  name                  = var.channel_name
   muting_rules_handling = "DONT_NOTIFY_FULLY_MUTED_ISSUES"
 
   issues_filter {


### PR DESCRIPTION
This pull request includes a change to the `namespace_policy.tf` file to make the configuration more flexible by using a variable for the channel name.

* [`namespace_policy.tf`](diffhunk://#diff-7b892cf9d537a3385d4c902a72c1590599549e66fa2d3e07a51d09bfd3c3ad7aL314-R314): Changed the `name` attribute in the `newrelic_workflow` resource to use `var.channel_name` instead of `newrelic_alert_policy.namespace[0].name` to allow for more dynamic configuration.