### PR TITLE
Update workflow name to include alert policy ID

### DIFF
--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -311,11 +311,11 @@ resource "newrelic_notification_channel" "google_chat_namespace" {
 resource "newrelic_workflow" "namespace" {
   count = length(var.namespaces) > 0 ? 1 : 0
 
-  name                  = var.channel_name
+  name                  = "${newrelic_alert_policy.namespace[0].id} - ${var.channel_name}"
   muting_rules_handling = "DONT_NOTIFY_FULLY_MUTED_ISSUES"
 
   issues_filter {
-    name = newrelic_alert_policy.namespace[0].name
+    name = newrelic_alert_policy.namespace[0].id
     type = "FILTER"
 
     predicate {


### PR DESCRIPTION
This pull request includes a change to the `namespace_policy.tf` file to improve the naming convention for New Relic workflows. The most important changes are:

* Updated the `name` attribute in the `newrelic_workflow` resource to include the `id` of the `newrelic_alert_policy` instead of just the `channel_name`. This makes the naming more descriptive and unique.
* Changed the `name` attribute in the `issues_filter` block to use the `id` of the `newrelic_alert_policy` instead of its `name`, ensuring consistency with the updated naming convention.