### PR TITLE
Add filter to exclude container from memory high alert

### DIFF
--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -57,7 +57,7 @@ resource "newrelic_nrql_alert_condition" "container_memory_high" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM K8sContainerSample SELECT average(requestedMemoryWorkingSetUtilization) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND requestedMemoryWorkingSetUtilization >= 85 FACET namespace, podName, containerName"
+    query = "FROM K8sContainerSample SELECT average(requestedMemoryWorkingSetUtilization) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND requestedMemoryWorkingSetUtilization >= 85 AND `label.one.newrelic.com/container-memory-high-alert` != 'None' FACET namespace, podName, containerName"
   }
 
   critical {


### PR DESCRIPTION
This pull request includes a modification to the `namespace_policy.tf` file to enhance the alert condition for high container memory usage by adding an additional filter to the NRQL query.

Enhancements to alert conditions:

* [`namespace_policy.tf`](diffhunk://#diff-7b892cf9d537a3385d4c902a72c1590599549e66fa2d3e07a51d09bfd3c3ad7aL60-R60): Updated the NRQL query in the `newrelic_nrql_alert_condition` resource to include an additional filter for the `label.one.newrelic.com/container-memory-high-alert` label, ensuring that containers marked with 'None' are excluded from the alert.