### PR TITLE
Add filters to exclude resources from alerting

### DIFF
--- a/cluster_policy.tf
+++ b/cluster_policy.tf
@@ -79,7 +79,7 @@ resource "newrelic_nrql_alert_condition" "node_memory_high" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM K8sNodeSample SELECT average(allocatableMemoryUtilization) WHERE clusterName = '${var.cluster_name}' AND allocatableMemoryUtilization >= 90 FACET nodeName"
+    query = "FROM K8sNodeSample SELECT average(allocatableMemoryUtilization) WHERE clusterName = '${var.cluster_name}' AND allocatableMemoryUtilization >= 90 AND `label.one.newrelic.com/node-memory-high-alert` != 'None' FACET nodeName"
   }
 
   critical {
@@ -112,7 +112,7 @@ resource "newrelic_nrql_alert_condition" "node_disk_high" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM K8sNodeSample SELECT average(fsCapacityUtilization) WHERE clusterName = '${var.cluster_name}' AND fsCapacityUtilization >= 90 FACET nodeName"
+    query = "FROM K8sNodeSample SELECT average(fsCapacityUtilization) WHERE clusterName = '${var.cluster_name}' AND fsCapacityUtilization >= 90 AND `label.one.newrelic.com/node-disk-high-alert` != 'None' FACET nodeName"
   }
 
   critical {

--- a/namespace_policy.tf
+++ b/namespace_policy.tf
@@ -24,7 +24,7 @@ resource "newrelic_nrql_alert_condition" "container_cpu_high" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM K8sContainerSample SELECT average(requestedCpuCoresUtilization) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND requestedCpuCoresUtilization >= 90 FACET namespace, podName, containerName"
+    query = "FROM K8sContainerSample SELECT average(requestedCpuCoresUtilization) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND requestedCpuCoresUtilization >= 90 AND `label.one.newrelic.com/container-cpu-high-alert` != 'None' FACET namespace, podName, containerName"
   }
 
   critical {
@@ -116,7 +116,7 @@ resource "newrelic_nrql_alert_condition" "job_not_ready" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM K8sPodSample SELECT latest(isReady) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND status != 'Succeeded' AND createdKind = 'Job' AND isReady != 1 FACET namespace, podName"
+    query = "FROM K8sPodSample SELECT latest(isReady) WHERE clusterName = '${var.cluster_name}' AND namespace IN (${local.joined_namespaces}) AND status != 'Succeeded' AND createdKind = 'Job' AND isReady != 1 AND `label.one.newrelic.com/job-ready-alert` != 'None' FACET namespace, podName"
   }
 
   critical {
@@ -201,7 +201,7 @@ resource "newrelic_nrql_alert_condition" "volume_out_of_space" {
   aggregation_timer              = 5
 
   nrql {
-    query = "FROM Metric SELECT average(k8s.volume.fsUsedPercent) WHERE k8s.clusterName = '${var.cluster_name}' AND k8s.namespaceName IN (${local.joined_namespaces}) AND k8s.volume.fsUsedPercent >= 75 FACET k8s.pvcName"
+    query = "FROM Metric SELECT average(k8s.volume.fsUsedPercent) WHERE k8s.clusterName = '${var.cluster_name}' AND k8s.namespaceName IN (${local.joined_namespaces}) AND k8s.volume.fsUsedPercent >= 75 AND `label.one.newrelic.com/volume-usage-high-alert` != 'None' FACET k8s.pvcName"
   }
 
   critical {


### PR DESCRIPTION
This pull request includes updates to the NRQL alert conditions in the `cluster_policy.tf` and `namespace_policy.tf` files to add additional filtering based on specific New Relic labels. The main changes involve modifying the NRQL queries to include new conditions that check for the presence of certain labels.

### Changes to NRQL alert conditions:

* `cluster_policy.tf`:
  * Updated `node_memory_high` alert condition to include a filter for the `label.one.newrelic.com/node-memory-high-alert` label.
  * Updated `node_disk_high` alert condition to include a filter for the `label.one.newrelic.com/node-disk-high-alert` label.

* `namespace_policy.tf`:
  * Updated `container_cpu_high` alert condition to include a filter for the `label.one.newrelic.com/container-cpu-high-alert` label.
  * Updated `job_not_ready` alert condition to include a filter for the `label.one.newrelic.com/job-ready-alert` label.
  * Updated `volume_out_of_space` alert condition to include a filter for the `label.one.newrelic.com/volume-usage-high-alert` label.